### PR TITLE
Remove local storage caching in dev mode

### DIFF
--- a/packages/sdk/src/fetcher/core/index.ts
+++ b/packages/sdk/src/fetcher/core/index.ts
@@ -3,7 +3,6 @@ import {
     ChainId,
     ERC20_ABI,
     CHAIN_ADDRESSES,
-    CACHER,
 } from "../../commons";
 import {
     cacheERC20Token,


### PR DESCRIPTION
When testing templates this might be detrimental as it might serve old files. In production caching is handled by a service worker so we're ok.