### PR TITLE
Implement KPI campaigns search on-chain with decentralize mode

### DIFF
--- a/packages/sdk/src/fetcher/index.ts
+++ b/packages/sdk/src/fetcher/index.ts
@@ -99,6 +99,7 @@ class FullFetcher implements IFullCarrotFetcher {
                   provider,
                   ipfsGatewayURL,
                   addresses,
+                  searchQuery,
               });
     }
 

--- a/packages/sdk/src/fetcher/on-chain/index.ts
+++ b/packages/sdk/src/fetcher/on-chain/index.ts
@@ -23,6 +23,8 @@ import {
     FetchTemplatesParams,
     IPartialCarrotFetcher,
 } from "../abstraction";
+import { searchKPItokens } from "../search";
+import { KPITokensObject } from "../serializer";
 
 // platform related interfaces
 const KPI_TOKEN_INTERFACE = new Interface(KPI_TOKEN_ABI);
@@ -123,6 +125,7 @@ class Fetcher implements IPartialCarrotFetcher {
         provider,
         ipfsGatewayURL,
         addresses,
+        searchQuery,
     }: FetchEntitiesParams): Promise<{ [address: string]: KPIToken }> {
         const { chainId } = await provider.getNetwork();
         enforce(chainId in ChainId, `unsupported chain with id ${chainId}`);
@@ -217,7 +220,7 @@ class Fetcher implements IPartialCarrotFetcher {
             addresses: allOracleAddresses,
         });
 
-        const allKPITokens: { [address: string]: KPIToken } = {};
+        const allKPITokens: KPITokensObject = {};
         const iUpperLimit =
             addresses && addresses.length > 0
                 ? addresses.length
@@ -300,6 +303,9 @@ class Fetcher implements IPartialCarrotFetcher {
                 kpiTokenFinalized
             );
         }
+
+        if (searchQuery) return searchKPItokens(searchQuery, allKPITokens);
+
         return allKPITokens;
     }
 

--- a/packages/sdk/src/fetcher/search/index.ts
+++ b/packages/sdk/src/fetcher/search/index.ts
@@ -1,0 +1,38 @@
+import { KPIToken } from "../../entities/kpi-token";
+import { KPITokensObject, transformInKPITokensObject } from "../serializer";
+
+export function searchKPItokens(
+    searchQuery: string,
+    allKPITokens: KPITokensObject
+) {
+    const filteredTokens = Object.values(allKPITokens).filter((token) =>
+        tokenSpecificationIncludesQuery(token, searchQuery)
+    );
+
+    return transformInKPITokensObject(filteredTokens);
+}
+
+function tokenSpecificationIncludesQuery(token: KPIToken, searchQuery: string) {
+    const query = searchQuery.toLowerCase();
+    const specification = token.specification;
+
+    return (
+        token.hasOwnProperty("specification") &&
+        (includesQuery(specification.title, query) ||
+            includesQuery(specification.description, query) ||
+            includesQuery(specification.tags, query))
+    );
+}
+
+function includesQuery(value: string | string[], query: string) {
+    const result =
+        typeof value === "string"
+            ? value.toString().toLowerCase()
+            : lowerCaseArray(value);
+
+    return result.includes(query);
+}
+
+function lowerCaseArray(stringsArray: string[]) {
+    return stringsArray.map((value) => value.toLowerCase());
+}

--- a/packages/sdk/src/fetcher/serializer/index.ts
+++ b/packages/sdk/src/fetcher/serializer/index.ts
@@ -1,0 +1,15 @@
+import { KPIToken } from "../../entities/kpi-token";
+
+export type KPITokensObject = Record<string, KPIToken>;
+
+export function transformInKPITokensObject(
+    filteredTokens: KPIToken[]
+): KPITokensObject {
+    return filteredTokens.reduce(
+        (kpiTokensObj: KPITokensObject, token: KPIToken) => {
+            kpiTokensObj[token.address] = token;
+            return kpiTokensObj;
+        },
+        {}
+    );
+}


### PR DESCRIPTION
When enabling decentralize mode, we connect directly on chain contract to get the data instead of subgraph. 

This PR adds search support to the on chain fetcher.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/5664434/226887380-a0e2026a-c8da-4b4b-a5e0-4943d6dbc435.png">

This is related to this PR: #185 
