### PR TITLE
feat: add campaign state and ordering filters to url with search params

### DIFF
--- a/packages/frontend/src/pages/campaigns/index.tsx
+++ b/packages/frontend/src/pages/campaigns/index.tsx
@@ -47,17 +47,23 @@ export const Campaigns = () => {
     const [currentPage, setCurrentPage] = useState(1);
     const { data, totalPages } = usePagination(results, currentPage, 4);
 
-    const handleOrderingChange = (orderingState: SelectOption) => {
-        const searchParams = new URLSearchParams(location.search);
-        searchParams.set("ordering", orderingState.label);
-        navigate(`?${searchParams}`);
-    };
+    const handleOrderingChange = useCallback(
+        (orderingState: SelectOption) => {
+            const searchParams = new URLSearchParams(location.search);
+            searchParams.set("ordering", orderingState.label);
+            navigate(`?${searchParams}`);
+        },
+        [location.search, navigate]
+    );
 
-    const handleStateChange = (campaignState: SelectOption) => {
-        const searchParams = new URLSearchParams(location.search);
-        searchParams.set("state", campaignState.label);
-        navigate(`?${searchParams}`);
-    };
+    const handleStateChange = useCallback(
+        (campaignState: SelectOption) => {
+            const searchParams = new URLSearchParams(location.search);
+            searchParams.set("state", campaignState.label);
+            navigate(`?${searchParams}`);
+        },
+        [location.search, navigate]
+    );
 
     const handlePageChange = useCallback(
         (pageNumber: SetStateAction<number>) => {

--- a/packages/frontend/src/pages/campaigns/index.tsx
+++ b/packages/frontend/src/pages/campaigns/index.tsx
@@ -23,6 +23,7 @@ import {
     CampaignOrder,
     CampaignState,
     getOrderByLabel,
+    getCampaignStateByLabel,
 } from "./select-options";
 import { Pagination } from "../../components/pagination";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -53,6 +54,12 @@ export const Campaigns = () => {
         navigate(`?${searchParams}`);
     };
 
+    const handleStateChange = (campaignState: SelectOption) => {
+        const searchParams = new URLSearchParams(location.search);
+        searchParams.set("state", campaignState.label);
+        navigate(`?${searchParams}`);
+    };
+
     const handlePageChange = (pageNumber: SetStateAction<number>) => {
         const searchParams = new URLSearchParams(location.search);
         searchParams.set("page", pageNumber.toString());
@@ -66,6 +73,8 @@ export const Campaigns = () => {
         const orderingParams =
             searchParams.get("ordering") ?? ORDERING_OPTIONS[0].label;
         setOrdering(getOrderByLabel(orderingParams));
+        const stateParams = searchParams.get("state") ?? STATE_OPTIONS[0].label;
+        setCampaignState(getCampaignStateByLabel(stateParams));
     }, [location]);
 
     // fetch data
@@ -143,7 +152,7 @@ export const Campaigns = () => {
                         onOrderingChange={handleOrderingChange}
                         state={campaignState}
                         stateOptions={STATE_OPTIONS}
-                        onStateChange={setCampaignState}
+                        onStateChange={handleStateChange}
                         onToggleFilters={toggleFilters}
                         filtersOpen={filtersOpen}
                         setSearchQuery={setSearchQuery}

--- a/packages/frontend/src/pages/campaigns/index.tsx
+++ b/packages/frontend/src/pages/campaigns/index.tsx
@@ -22,8 +22,7 @@ import {
     STATE_OPTIONS,
     CampaignOrder,
     CampaignState,
-    getOrderByLabel,
-    getCampaignStateByLabel,
+    getOptionByLabel,
 } from "./select-options";
 import { Pagination } from "../../components/pagination";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -72,9 +71,9 @@ export const Campaigns = () => {
         setCurrentPage(parseInt(pageParams));
         const orderingParams =
             searchParams.get("ordering") ?? ORDERING_OPTIONS[0].label;
-        setOrdering(getOrderByLabel(orderingParams));
+        setOrdering(getOptionByLabel(ORDERING_OPTIONS, orderingParams));
         const stateParams = searchParams.get("state") ?? STATE_OPTIONS[0].label;
-        setCampaignState(getCampaignStateByLabel(stateParams));
+        setCampaignState(getOptionByLabel(STATE_OPTIONS, stateParams));
     }, [location]);
 
     // fetch data

--- a/packages/frontend/src/pages/campaigns/index.tsx
+++ b/packages/frontend/src/pages/campaigns/index.tsx
@@ -22,6 +22,7 @@ import {
     STATE_OPTIONS,
     CampaignOrder,
     CampaignState,
+    getOrderByLabel,
 } from "./select-options";
 import { Pagination } from "../../components/pagination";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -46,6 +47,12 @@ export const Campaigns = () => {
     const [currentPage, setCurrentPage] = useState(1);
     const { data, totalPages } = usePagination(results, currentPage, 4);
 
+    const handleOrderingChange = (orderingState: SelectOption) => {
+        const searchParams = new URLSearchParams(location.search);
+        searchParams.set("ordering", orderingState.label);
+        navigate(`?${searchParams}`);
+    };
+
     const handlePageChange = (pageNumber: SetStateAction<number>) => {
         const searchParams = new URLSearchParams(location.search);
         searchParams.set("page", pageNumber.toString());
@@ -56,6 +63,9 @@ export const Campaigns = () => {
         const searchParams = new URLSearchParams(location.search);
         const pageParams = searchParams.get("page") ?? "1";
         setCurrentPage(parseInt(pageParams));
+        const orderingParams =
+            searchParams.get("ordering") ?? ORDERING_OPTIONS[0].label;
+        setOrdering(getOrderByLabel(orderingParams));
     }, [location]);
 
     // fetch data
@@ -130,7 +140,7 @@ export const Campaigns = () => {
                     <CampaignsTopNav
                         ordering={ordering}
                         orderingOptions={ORDERING_OPTIONS}
-                        onOrderingChange={setOrdering}
+                        onOrderingChange={handleOrderingChange}
                         state={campaignState}
                         stateOptions={STATE_OPTIONS}
                         onStateChange={setCampaignState}

--- a/packages/frontend/src/pages/campaigns/select-options/index.ts
+++ b/packages/frontend/src/pages/campaigns/select-options/index.ts
@@ -1,4 +1,14 @@
+import { SelectOption } from "@carrot-kpi/ui";
 import { t } from "i18next";
+
+export const getOptionByLabel = (
+    optionsList: SelectOption[],
+    label: string
+) => {
+    const option = optionsList.find((option) => option.label === label);
+    if (option) return option;
+    else return optionsList[0];
+};
 
 export enum CampaignOrder {
     NEWEST,
@@ -15,12 +25,6 @@ export const ORDERING_OPTIONS = [
         value: CampaignOrder.OLDEST,
     },
 ];
-
-export const getOrderByLabel = (label: string) => {
-    const order = ORDERING_OPTIONS.find((order) => order.label === label);
-    if (order) return order;
-    else return ORDERING_OPTIONS[0];
-};
 
 export enum CampaignState {
     ALL,
@@ -47,9 +51,3 @@ export const STATE_OPTIONS = [
         value: CampaignState.FINALIZED,
     },
 ];
-
-export const getCampaignStateByLabel = (label: string) => {
-    const state = STATE_OPTIONS.find((state) => state.label === label);
-    if (state) return state;
-    else return STATE_OPTIONS[0];
-};

--- a/packages/frontend/src/pages/campaigns/select-options/index.ts
+++ b/packages/frontend/src/pages/campaigns/select-options/index.ts
@@ -47,3 +47,9 @@ export const STATE_OPTIONS = [
         value: CampaignState.FINALIZED,
     },
 ];
+
+export const getCampaignStateByLabel = (label: string) => {
+    const state = STATE_OPTIONS.find((state) => state.label === label);
+    if (state) return state;
+    else return STATE_OPTIONS[0];
+};

--- a/packages/frontend/src/pages/campaigns/select-options/index.ts
+++ b/packages/frontend/src/pages/campaigns/select-options/index.ts
@@ -16,6 +16,12 @@ export const ORDERING_OPTIONS = [
     },
 ];
 
+export const getOrderByLabel = (label: string) => {
+    const order = ORDERING_OPTIONS.find((order) => order.label === label);
+    if (order) return order;
+    else return ORDERING_OPTIONS[0];
+};
+
 export enum CampaignState {
     ALL,
     ACTIVE,


### PR DESCRIPTION
**Summary**
this PR adds campaign state and ordering filters to url so it can keep the filters when sharing url.

closes #221 
