### PR TITLE
Mobile compatibility

### DIFF
--- a/packages/ui/src/components/input/date-time/index.tsx
+++ b/packages/ui/src/components/input/date-time/index.tsx
@@ -46,14 +46,6 @@ export const DateTimeInput = forwardRef<HTMLInputElement, DateTimeInputProps>(
         const [open, setOpen] = useState(false);
         const [modal, setModal] = useState(false);
 
-        const resizeObserver = useRef(
-            new ResizeObserver((entries) => {
-                const { width } = entries[0].contentRect;
-                if (width < 640) setModal(true);
-                else setModal(false);
-            })
-        );
-
         const resolvedId = id || generatedId;
 
         useClickAway(popoverRef, () => {
@@ -61,16 +53,23 @@ export const DateTimeInput = forwardRef<HTMLInputElement, DateTimeInputProps>(
         });
 
         useEffect(() => {
-            resizeObserver.current.observe(document.body);
+            const resizeObserver = new ResizeObserver((entries) => {
+                const { width } = entries[0].contentRect;
+                if (width < 640) setModal(true);
+                else setModal(false);
+            });
+
+            resizeObserver.observe(document.body);
             return () => {
                 // eslint-disable-next-line react-hooks/exhaustive-deps
-                resizeObserver.current.unobserve(document.body);
+                resizeObserver.unobserve(document.body);
             };
         }, []);
 
         const handlePickerOpen = useCallback(() => {
             setOpen(true);
         }, []);
+
         const handlePickerClose = useCallback(() => {
             setOpen(false);
         }, []);

--- a/packages/ui/src/components/input/date-time/index.tsx
+++ b/packages/ui/src/components/input/date-time/index.tsx
@@ -44,13 +44,13 @@ export const DateTimeInput = forwardRef<HTMLInputElement, DateTimeInputProps>(
         const [anchorEl, setAnchorEl] = useState<HTMLInputElement | null>(null);
         const popoverRef = useRef<HTMLDivElement>(null);
         const [open, setOpen] = useState(false);
-        const [mobile, setMobile] = useState(false);
+        const [modal, setModal] = useState(false);
 
         const resizeObserver = useRef(
             new ResizeObserver((entries) => {
                 const { width } = entries[0].contentRect;
-                if (width < 768) setMobile(true);
-                else setMobile(false);
+                if (width < 640) setModal(true);
+                else setModal(false);
             })
         );
 
@@ -105,7 +105,7 @@ export const DateTimeInput = forwardRef<HTMLInputElement, DateTimeInputProps>(
                         value ? dayjs(value).format("L HH:mm:ss") : undefined
                     }
                 />
-                {mobile ? (
+                {modal ? (
                     <Modal open={open} onDismiss={handlePickerClose}>
                         <DateTimePicker
                             value={value}

--- a/packages/ui/src/components/input/date-time/picker/index.tsx
+++ b/packages/ui/src/components/input/date-time/picker/index.tsx
@@ -9,7 +9,7 @@ import { rectifyDate, resolvedValue } from "../../../../utils/date";
 const cellListStyles = mergedCva(
     [
         "cui-h-52",
-        "cui-w-10",
+        "cui-w-full md:cui-w-10",
         "cui-py-2",
         "cui-overflow-y-auto",
         "cui-scrollbar",
@@ -124,8 +124,8 @@ export const DateTimePicker = ({
     );
 
     return (
-        <div className="cui-flex">
-            <div className="cui-p-3">
+        <div className="cui-flex cui-flex-col md:cui-flex-row cui-bg-white dark:cui-bg-black cui-rounded-xxl">
+            <div className="cui-p-3 cui-pb-0 md:cui-p-3">
                 <DatePicker
                     value={value}
                     onChange={handleDateChange}
@@ -137,7 +137,7 @@ export const DateTimePicker = ({
             <div className="cui-flex cui-flex-col">
                 <Typography
                     className={{
-                        root: "cui-p-2 cui-border-b cui-border-black dark:cui-border-white cui-text-center",
+                        root: "cui-p-2 cui-border-none md:cui-border-b cui-border-black dark:cui-border-white cui-text-center",
                     }}
                 >
                     {value ? dayjs(value).format("HH:mm:ss") : "--:--:--"}

--- a/packages/ui/src/components/input/date/index.tsx
+++ b/packages/ui/src/components/input/date/index.tsx
@@ -46,14 +46,6 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
         const [open, setOpen] = useState(false);
         const [modal, setModal] = useState(false);
 
-        const resizeObserver = useRef(
-            new ResizeObserver((entries) => {
-                const { width } = entries[0].contentRect;
-                if (width < 640) setModal(true);
-                else setModal(false);
-            })
-        );
-
         const resolvedId = id || generatedId;
 
         useClickAway(popoverRef, () => {
@@ -61,16 +53,23 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
         });
 
         useEffect(() => {
-            resizeObserver.current.observe(document.body);
+            const resizeObserver = new ResizeObserver((entries) => {
+                const { width } = entries[0].contentRect;
+                if (width < 640) setModal(true);
+                else setModal(false);
+            });
+
+            resizeObserver.observe(document.body);
             return () => {
                 // eslint-disable-next-line react-hooks/exhaustive-deps
-                resizeObserver.current.unobserve(document.body);
+                resizeObserver.unobserve(document.body);
             };
         });
 
         const handlePickerOpen = useCallback(() => {
             setOpen(true);
         }, []);
+
         const handlePickerClose = useCallback(() => {
             setOpen(false);
         }, []);

--- a/packages/ui/src/components/input/date/index.tsx
+++ b/packages/ui/src/components/input/date/index.tsx
@@ -1,9 +1,16 @@
-import React, { forwardRef, useRef, useState, useCallback, useId } from "react";
+import React, {
+    forwardRef,
+    useRef,
+    useState,
+    useCallback,
+    useId,
+    useEffect,
+} from "react";
 import { ReactElement } from "react";
 import { BaseInputProps } from "../commons";
 import dayjs from "dayjs";
 import { TextInput } from "../text";
-import { Popover } from "../../utils";
+import { Modal, Popover } from "../../utils";
 import { ReactComponent as Calendar } from "../../../assets/calendar.svg";
 import { DatePicker, DatePickerProps } from "./picker";
 import { useClickAway } from "react-use";
@@ -37,6 +44,15 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
         const [anchorEl, setAnchorEl] = useState<HTMLInputElement | null>(null);
         const popoverRef = useRef<HTMLDivElement>(null);
         const [open, setOpen] = useState(false);
+        const [modal, setModal] = useState(false);
+
+        const resizeObserver = useRef(
+            new ResizeObserver((entries) => {
+                const { width } = entries[0].contentRect;
+                if (width < 640) setModal(true);
+                else setModal(false);
+            })
+        );
 
         const resolvedId = id || generatedId;
 
@@ -44,8 +60,19 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
             setOpen(false);
         });
 
+        useEffect(() => {
+            resizeObserver.current.observe(document.body);
+            return () => {
+                // eslint-disable-next-line react-hooks/exhaustive-deps
+                resizeObserver.current.unobserve(document.body);
+            };
+        });
+
         const handlePickerOpen = useCallback(() => {
             setOpen(true);
+        }, []);
+        const handlePickerClose = useCallback(() => {
+            setOpen(false);
         }, []);
 
         const handleChange = useCallback(
@@ -84,22 +111,35 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
                     onClick={handlePickerOpen}
                     value={value ? dayjs(value).format("L") : undefined}
                 />
-                <Popover
-                    anchor={anchorEl}
-                    ref={popoverRef}
-                    open={open}
-                    placement="bottom-start"
-                    className={{
-                        root: "cui-p-2 cui-flex cui-flex-col cui-gap-3",
-                    }}
-                >
-                    <DatePicker
-                        onChange={handleChange}
-                        value={value}
-                        min={min}
-                        max={max}
-                    />
-                </Popover>
+                {modal ? (
+                    <Modal open={open} onDismiss={handlePickerClose}>
+                        <div className="cui-p-3 cui-rounded-xxl cui-bg-white dark:cui-bg-black">
+                            <DatePicker
+                                value={value}
+                                onChange={handleChange}
+                                min={min}
+                                max={max}
+                            />
+                        </div>
+                    </Modal>
+                ) : (
+                    <Popover
+                        anchor={anchorEl}
+                        ref={popoverRef}
+                        open={open}
+                        placement="bottom-start"
+                        className={{
+                            root: "cui-p-3 cui-flex cui-flex-col cui-gap-3",
+                        }}
+                    >
+                        <DatePicker
+                            onChange={handleChange}
+                            value={value}
+                            min={min}
+                            max={max}
+                        />
+                    </Popover>
+                )}
             </>
         );
     }

--- a/packages/ui/src/components/navigation/stepper/index.tsx
+++ b/packages/ui/src/components/navigation/stepper/index.tsx
@@ -92,13 +92,13 @@ const labelStyles = mergedCva([], {
                 "cui-text-center",
                 "cui-max-w-[100px]",
                 "cui-text-ellipsis",
-                "cui-overflow-hidden ...",
+                "cui-overflow-hidden",
             ],
             automatic: [
                 "cui-text-center md:cui-text-left",
                 "cui-max-w-[100px] md:cui-max-w-full",
                 "cui-text-ellipsis",
-                "cui-overflow-hidden ...",
+                "cui-overflow-hidden",
             ],
         },
         visible: {
@@ -115,7 +115,7 @@ const labelStyles = mergedCva([], {
         {
             layout: "horizontal",
             visible: true,
-            className: ["cui-flex", "cui-line-clamp-2"],
+            className: ["cui-flex"],
         },
         {
             layout: "automatic",
@@ -125,7 +125,7 @@ const labelStyles = mergedCva([], {
         {
             layout: "automatic",
             visible: true,
-            className: ["cui-flex", "cui-line-clamp-2"],
+            className: ["cui-flex"],
         },
     ],
 });
@@ -140,6 +140,7 @@ export interface StepperProps {
     className?: {
         root?: string;
         step?: string;
+        stepLabel?: string;
         square?: string;
         line?: string;
     };
@@ -207,6 +208,7 @@ export const Stepper = ({
                                 root: labelStyles({
                                     layout,
                                     visible: currentStep,
+                                    className: className?.stepLabel,
                                 }),
                             }}
                         >


### PR DESCRIPTION
The `DatePicker`  component was causing weird horizontal scrolling on mobile devices since the picker contained by the popover is already on the DOM (with 0 opacity).
Having the `DatePicker` popover as a modal on mobile solves the issue.