### PR TITLE
feat(frontend): implement staging mode only supporting testnets

### DIFF
--- a/packages/frontend/craco.config.js
+++ b/packages/frontend/craco.config.js
@@ -13,6 +13,7 @@ module.exports = {
                 }),
                 new webpack.DefinePlugin({
                     __PREVIEW_MODE__: JSON.stringify(false),
+                    __STAGING__: JSON.stringify(process.env.STAGING === "true"),
                 }),
                 new webpack.ProvidePlugin({
                     Buffer: ["buffer", "Buffer"],

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -29,7 +29,8 @@
         "build-library": "yarn clean && rollup -c rollup.config.mjs",
         "test": "react-scripts test --env=jsdom --watchAll=false --passWithNoTests",
         "size-limit": "size-limit",
-        "start": "craco start"
+        "start": "craco start",
+        "start-staging": "STAGING=true craco start"
     },
     "dependencies": {
         "@carrot-kpi/react": "*",

--- a/packages/frontend/src/components/connect-wallet/index.tsx
+++ b/packages/frontend/src/components/connect-wallet/index.tsx
@@ -1,6 +1,6 @@
 import { ChainId } from "@carrot-kpi/sdk";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { SUPPORTED_CHAINS } from "../../constants";
+import { ENABLED_CHAINS, SUPPORTED_CHAINS } from "../../constants";
 import Error from "../../icons/error";
 import CaretDown from "../../icons/caret-down";
 import { useTranslation } from "react-i18next";
@@ -85,11 +85,12 @@ export const ConnectWallet = () => {
         [activeConnector]
     );
 
+    const multipleEnabledChains = Object.keys(ENABLED_CHAINS).length > 1;
     const chainId = chain?.id || Number.MAX_SAFE_INTEGER;
     const chainName = chain?.name || t("connect.wallet.unknown");
-    const supportedChain = !!chainId && !!SUPPORTED_CHAINS[chainId as ChainId];
+    const supportedChain = !!chainId && !!ENABLED_CHAINS[chainId];
     const Logo = supportedChain
-        ? SUPPORTED_CHAINS[chainId as ChainId].logo
+        ? ENABLED_CHAINS[chainId as ChainId].logo
         : Error;
     return (
         <>
@@ -119,9 +120,15 @@ export const ConnectWallet = () => {
             <div className="flex gap-4">
                 <div
                     className={`h-12 w-fit flex items-center ${
-                        __PREVIEW_MODE__ ? "" : "cursor-pointer"
+                        __PREVIEW_MODE__ || !multipleEnabledChains
+                            ? ""
+                            : "cursor-pointer"
                     } gap-3`}
-                    onClick={handleNetworksPopoverOpen}
+                    onClick={
+                        multipleEnabledChains
+                            ? handleNetworksPopoverOpen
+                            : undefined
+                    }
                     ref={setNetworksPopoverAnchor}
                 >
                     <ChainIcon
@@ -141,7 +148,9 @@ export const ConnectWallet = () => {
                             {supportedChain ? chainName : "Unsupported"}
                         </Typography>
                     </div>
-                    {!__PREVIEW_MODE__ && <CaretDown className="w-3" />}
+                    {!__PREVIEW_MODE__ && multipleEnabledChains && (
+                        <CaretDown className="w-3" />
+                    )}
                 </div>
                 {address ? (
                     <Button

--- a/packages/frontend/src/constants/index.ts
+++ b/packages/frontend/src/constants/index.ts
@@ -14,6 +14,7 @@ export interface AugmentedChain extends Chain {
         SVGProps<SVGSVGElement> & { title?: string | undefined }
     >;
     iconBackgroundColor: string;
+    enabled: boolean;
 }
 
 export const SUPPORTED_CHAINS: Record<ChainId, AugmentedChain> = {
@@ -21,15 +22,32 @@ export const SUPPORTED_CHAINS: Record<ChainId, AugmentedChain> = {
         ...gnosis,
         logo: GnosisLogo,
         iconBackgroundColor: "#04795b",
+        enabled: !__STAGING__,
     },
     [ChainId.SEPOLIA]: {
         ...sepolia,
         logo: EthereumLogo,
         iconBackgroundColor: "#8637ea",
+        enabled: true,
     },
 };
 
-export const DEFAULT_CHAIN: Chain = Object.values(SUPPORTED_CHAINS)[0];
+export const ENABLED_CHAINS: { [chainId: number]: AugmentedChain } =
+    Object.entries(SUPPORTED_CHAINS).reduce(
+        (
+            accumulator: { [chainId: number]: AugmentedChain },
+            [chainId, augmentedChain]
+        ) => {
+            if (augmentedChain.enabled)
+                accumulator[parseInt(chainId)] = augmentedChain;
+            return accumulator;
+        },
+        {}
+    );
+
+export const DEFAULT_CHAIN: Chain = Object.values(ENABLED_CHAINS).filter(
+    (chain) => chain.enabled
+)[0];
 
 export interface NavbarLink {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/frontend/src/react-app-env.d.ts
+++ b/packages/frontend/src/react-app-env.d.ts
@@ -6,6 +6,7 @@ import { CARROT_KPI_FRONTEND_I18N_NAMESPACE } from "./constants";
 
 declare global {
     const __PREVIEW_MODE__: boolean;
+    const __STAGING__: boolean;
 }
 
 declare module "i18next" {

--- a/packages/frontend/src/standalone-setup/index.ts
+++ b/packages/frontend/src/standalone-setup/index.ts
@@ -4,7 +4,7 @@ import { CoinbaseWalletConnector } from "wagmi/connectors/coinbaseWallet";
 import { WalletConnectConnector } from "wagmi/connectors/walletConnect";
 import { infuraProvider } from "wagmi/providers/infura";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
-import { SUPPORTED_CHAINS } from "../constants";
+import { ENABLED_CHAINS } from "../constants";
 import { ReadonlyConnector } from "../connectors";
 import { Chain, ChainProviderFn, Connector } from "wagmi";
 import { FrameConnector } from "../connectors/frame";
@@ -16,7 +16,7 @@ export let standaloneSupportedChains: Chain[] = [];
 export let standaloneProviders: ChainProviderFn[] = [];
 export let getStandaloneConnectors: () => Connector[] = () => [];
 if (!__PREVIEW_MODE__) {
-    standaloneSupportedChains = Object.values(SUPPORTED_CHAINS);
+    standaloneSupportedChains = Object.values(ENABLED_CHAINS);
     standaloneProviders = [
         infuraProvider({ apiKey: INFURA_PROJECT_ID }),
         jsonRpcProvider({


### PR DESCRIPTION
This first PR implements staging mode for the frontend. Staging mode only has access to testnets.

### To test

Test what happens when the user is connected to a production network which is still supported by Carrot such as Gnosis. What should happen is that transactions (such as KPI token creations) are not allowed there. 