### PR TITLE
chore: revert not passing t function to federated components

### DIFF
--- a/packages/react/src/components/template-component/index.tsx
+++ b/packages/react/src/components/template-component/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { /* useEffect, */ useLayoutEffect } from "react";
+import React, { useEffect, useLayoutEffect } from "react";
 import { useTemplateModule } from "../../hooks/useTemplateModule";
-// import { addBundleForTemplate } from "../../i18n";
+import { addBundleForTemplate } from "../../i18n";
 import { useState } from "react";
 import { cva } from "class-variance-authority";
 import { useStagingMode, useTheme } from "../../hooks";
@@ -20,11 +20,8 @@ const wrapperStyles = cva(["w-full", "h-full"], {
 
 export type NamespacedTranslateFunction = (key: any, options?: any) => any;
 
-// const TRANSLATE_CACHE: { [namespace: string]: NamespacedTranslateFunction } =
-//     {};
-
-// FIXME: not passing the t function to the component is only for
-// testing purposes. Once the testing has been done, revert these changes
+const TRANSLATE_CACHE: { [namespace: string]: NamespacedTranslateFunction } =
+    {};
 
 export function TemplateComponent({
     entity,
@@ -44,7 +41,7 @@ export function TemplateComponent({
             ? `${chain.id}-${template.id}-${template.version}-${template.address}-${type}-staging-${stagingMode}`
             : undefined;
 
-    const { loading, /* bundle, */ Component } = useTemplateModule(
+    const { loading, bundle, Component } = useTemplateModule(
         entity,
         type,
         template,
@@ -54,26 +51,26 @@ export function TemplateComponent({
     const systemDarkTheme = useMedia("(prefers-color-scheme: dark)");
 
     const [dark, setDark] = useState(false);
-    // const [translateWithNamespace, setTranslateWithNamespace] =
-    //     useState<NamespacedTranslateFunction>(
-    //         !!template && !!entry && TRANSLATE_CACHE[entry]
-    //             ? () => TRANSLATE_CACHE[entry]
-    //             : () => () => ""
-    //     );
+    const [translateWithNamespace, setTranslateWithNamespace] =
+        useState<NamespacedTranslateFunction>(
+            !!template && !!entry && TRANSLATE_CACHE[entry]
+                ? () => TRANSLATE_CACHE[entry]
+                : () => () => ""
+        );
 
-    // useEffect(() => {
-    //     if (!template || !bundle || !entry) return;
-    //     if (TRANSLATE_CACHE[entry]) {
-    //         setTranslateWithNamespace(() => TRANSLATE_CACHE[entry]);
-    //         return;
-    //     }
-    //     addBundleForTemplate(i18n, entry, bundle);
-    //     const namespacedTranslate = (key: any, options?: any) => {
-    //         return i18n.t(key, { ...options, ns: entry });
-    //     };
-    //     TRANSLATE_CACHE[entry] = namespacedTranslate;
-    //     setTranslateWithNamespace(() => namespacedTranslate);
-    // }, [bundle, template, type, i18n, entry]);
+    useEffect(() => {
+        if (!template || !bundle || !entry) return;
+        if (TRANSLATE_CACHE[entry]) {
+            setTranslateWithNamespace(() => TRANSLATE_CACHE[entry]);
+            return;
+        }
+        addBundleForTemplate(i18n, entry, bundle);
+        const namespacedTranslate = (key: any, options?: any) => {
+            return i18n.t(key, { ...options, ns: entry });
+        };
+        TRANSLATE_CACHE[entry] = namespacedTranslate;
+        setTranslateWithNamespace(() => namespacedTranslate);
+    }, [bundle, template, type, i18n, entry]);
 
     useLayoutEffect(() => {
         setDark(
@@ -97,7 +94,7 @@ export function TemplateComponent({
                 <Component
                     {...additionalProps}
                     i18n={i18n}
-                    // t={translateWithNamespace}
+                    t={translateWithNamespace}
                     template={template}
                 />
             </ErrorBoundary>

--- a/packages/react/src/types/templates.ts
+++ b/packages/react/src/types/templates.ts
@@ -4,7 +4,7 @@ import {
     ResolvedOracleWithData,
 } from "@carrot-kpi/sdk";
 import type { i18n } from "i18next";
-// import type { NamespacedTranslateFunction } from "../components";
+import type { NamespacedTranslateFunction } from "../components";
 import { type Tx, TxType } from "./transactions";
 import type { NavigateFunction } from "react-router-dom";
 import { ResolvedTemplate } from "@carrot-kpi/sdk";
@@ -35,9 +35,7 @@ export type TemplateComponentProps = Omit<
 export interface BaseRemoteTemplateComponentProps {
     i18n: i18n;
     template: ResolvedTemplate;
-    // FIXME: not having the t function here is only for testing purposes.
-    // Once the testing has been done, revert these changes
-    // t: NamespacedTranslateFunction;
+    t: NamespacedTranslateFunction;
 }
 
 export interface OracleInitializationBundle {


### PR DESCRIPTION
Revert "feat(react): avoid passing t function to federated components (#292)"

This reverts commit a1d2d3cbd5b9ea484c6261e462361c0054da5066.